### PR TITLE
Enable support for months and years

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,19 @@ possible, otherwise a floating-point number)::
     >>> parse('1.2 minutes')
     72
 
+For months and years, the library does not consider complications such as leap-
+years and leap-seconds. Instead, it assumes "30 days for a month" and "365 days
+for a year" as the basis for calculations with those units.
+
+- ``2 mo``
+- ``2 months``
+- ``3y``
+- ``3 years``
+- ``1y2mo3w4d5h6m7s8ms``
+
+Notes
+-----
+
 A number of seconds can be converted back into a string using the
 ``datetime`` module in the standard library, as noted in
 `this other StackOverflow question <http://stackoverflow.com/questions/538666/python-format-timedelta-to-string>`_::

--- a/pytimeparse2.py
+++ b/pytimeparse2.py
@@ -36,6 +36,8 @@ import typing
 import re
 
 SIGN = r'(?P<sign>[+|-]|\+)?'
+YEARS = r'(?P<years>[\d.]+)\s*(?:ys?|yrs?.?|years?)'
+MONTHS = r'(?P<months>[\d.]+)\s*(?:mos?.?|mths?.?|months?)'
 WEEKS = r'(?P<weeks>[\d.]+)\s*(?:w|wks?|weeks?)'
 DAYS = r'(?P<days>[\d.]+)\s*(?:d|dys?|days?)'
 HOURS = r'(?P<hours>[\d.]+)\s*(?:h|hrs?|hours?)'
@@ -50,6 +52,8 @@ DAYCLOCK = (r'(?P<days>\d+):(?P<hours>\d{2}):'
             r'(?P<mins>\d{2}):(?P<secs>\d{2}(?:\.\d+)?)')
 
 MULTIPLIERS = {
+    'years': 60 * 60 * 24 * 365,
+    'months': 60 * 60 * 24 * 30,
     'weeks': 60 * 60 * 24 * 7,
     'days': 60 * 60 * 24,
     'hours': 60 * 60,
@@ -68,11 +72,14 @@ def OPTSEP(x):
 
 
 TIMEFORMATS = [
+    rf'{OPTSEP(YEARS)}\s*{OPTSEP(MONTHS)}\s*{OPTSEP(WEEKS)}\s*{OPTSEP(DAYS)}\s*{OPTSEP(HOURS)}\s*{OPTSEP(MINS)}\s*{OPT(SECS)}\s*{OPT(MILLIS)}',
     rf'{OPTSEP(WEEKS)}\s*{OPTSEP(DAYS)}\s*{OPTSEP(HOURS)}\s*{OPTSEP(MINS)}\s*{OPT(SECS)}\s*{OPT(MILLIS)}',
     rf'{MINCLOCK}',
     rf'{OPTSEP(WEEKS)}\s*{OPTSEP(DAYS)}\s*{HOURCLOCK}',
     rf'{DAYCLOCK}',
     rf'{SECCLOCK}',
+    rf'{YEARS}',
+    rf'{MONTHS}',
 ]
 
 COMPILED_SIGN = re.compile(r'\s*' + SIGN + r'\s*(?P<unsigned>.*)$')
@@ -93,7 +100,9 @@ def _interpret_as_minutes(sval, mdict):
     {'hours': '1', 'mins': '24'}
     """
     if sval.count(':') == 1 and '.' not in sval and (('hours' not in mdict) or (mdict['hours'] is None)) and (
-            ('days' not in mdict) or (mdict['days'] is None)) and (('weeks' not in mdict) or (mdict['weeks'] is None)):
+            ('days' not in mdict) or (mdict['days'] is None)) and (('weeks' not in mdict) or (mdict['weeks'] is None)) \
+            and (('months' not in mdict) or (mdict['months'] is None)) \
+            and (('years' not in mdict) or (mdict['years'] is None)):
         mdict['hours'] = mdict['mins']
         mdict['mins'] = mdict['secs']
         mdict.pop('secs')

--- a/tests.py
+++ b/tests.py
@@ -25,6 +25,8 @@ class TestTimeparse(unittest.TestCase):
 
     def test_mins(self):
         """Test parsing minutes."""
+        self.assertEqual(re.match(timeparse.MINS, '32m').groupdict(),
+                         {'mins': '32'})
         self.assertEqual(re.match(timeparse.MINS, '32min').groupdict(),
                          {'mins': '32'})
         self.assertEqual(re.match(timeparse.MINS, '32mins').groupdict(),
@@ -54,6 +56,50 @@ class TestTimeparse(unittest.TestCase):
                          {'hours': '32'})
         self.assertEqual(re.match(timeparse.HOURS, '32 h').groupdict(),
                          {'hours': '32'})
+
+    def test_months(self):
+        """Test parsing months."""
+        self.assertEqual(re.match(timeparse.MONTHS, '32mo').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32mon').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32month').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32months').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32 mo').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32 months').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32mos').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '32mths').groupdict(),
+                         {'months': '32'})
+        self.assertEqual(re.match(timeparse.MONTHS, '2.3mo').groupdict(),
+                         {'months': '2.3'})
+        self.assertEqual(re.match(timeparse.MONTHS, '2.5mo').groupdict(),
+                         {'months': '2.5'})
+
+    def test_years(self):
+        """Test parsing years."""
+        self.assertEqual(re.match(timeparse.YEARS, '32y').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32ys').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32yrs').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32year').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32years').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32 y').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '32 years').groupdict(),
+                         {'years': '32'})
+        self.assertEqual(re.match(timeparse.YEARS, '2.3y').groupdict(),
+                         {'years': '2.3'})
+        self.assertEqual(re.match(timeparse.YEARS, '2.5y').groupdict(),
+                         {'years': '2.5'})
 
     def test_time(self):
         """Test parsing time expression."""
@@ -376,6 +422,9 @@ class TestTimeparse(unittest.TestCase):
         self.assertEqual(timeparse.parse('10.1'), 10)
         self.assertEqual(timeparse.parse('-10'), -10)
         self.assertEqual(timeparse.parse('-10.1'), -10)
+
+    def test_combined(self):
+        self.assertEqual(timeparse.parse('1y2mo3w4d5h6m7s8ms'), 38898367.008)
 
     def test_doctest(self):
         """Run timeparse doctests."""


### PR DESCRIPTION
Dear Sergey,

first things first: Thanks a stack for what looks like you have been taking over maintenance for this fine package from @wroberts and giving it some love. Cheers!

We are very happy that you listened to the needs of the community and integrated ef62cf10b0 and 0a71785c already. In the same spirit, we would like to submit a patch which is also of interest to other people and humbly ask for your kindness to integrate it into the code base.

We are aware that this topic has been discussed at https://github.com/wroberts/pytimeparse/issues/7 and https://github.com/wroberts/pytimeparse/issues/13 already. While the original author was not keen to support it [1], we built upon https://github.com/wroberts/pytimeparse/pull/10 by @duramato, submitted https://github.com/wroberts/pytimeparse/pull/26 once more [2] and, at the same time, would like to add some energy by sending it to you as well.

With kind regards,
Andreas.

[1]
> @wroberts: Months and years are periods of time directly related to the calendar; they could be included in `pytimeparse`, but only relative to a particular date (such as the current system time). There's also complications such as leap-years and leap-seconds. For the moment, I chose to only include time expressions which correspond to a fixed length of time.
>
> -- https://github.com/wroberts/pytimeparse/issues/7#issuecomment-62305025

[2]
> @amotl: I still believe it would be reasonable to assume "30 days for a month" and "365 days for a year" as the basis for calculations with those units. I agree that this approximation should be documented well.
>
> -- https://github.com/wroberts/pytimeparse/pull/26#issue-1057829086


/cc @jd, @duramato, @martinb3, @jaraco, @jpopelka, @jhtitor, @Toldry, @hozn.
