### PR TITLE
Normalize returned timedelta objects

### DIFF
--- a/pytimeparse2.py
+++ b/pytimeparse2.py
@@ -245,7 +245,7 @@ def parse(
                 return int(new_value)
             else:
                 return new_value
-        return value
+        return value.normalized()
     except Exception:
         if raise_exception:
             raise


### PR DESCRIPTION
I'm sorry about all the PRs, but this should remove any decimals in the `relativedelta`s before returning them.